### PR TITLE
Update custom theme path in Drupal Developer Exam Question 8

### DIFF
--- a/docs/self-evaluation/drupal-developer-exam-answers.md
+++ b/docs/self-evaluation/drupal-developer-exam-answers.md
@@ -40,7 +40,7 @@
 > **Reference**: [Working With Twig Templates](https://www.drupal.  org/docs/develop/theming-drupal/twig-in-drupal/working-with-twig-templates)  
 
 **8. Where are theme `.twig` files stored in a custom Drupal theme?**
-> **Answer**: B. `/themes/{theme_name}/templates/`    
+> **Answer**: B. `/themes/custom/{theme_name}/templates/`    
 > **Explanation**: In a custom Drupal theme, Twig template files are typically stored in the `templates`   directory within the theme's folder.  
 > **Reference**: [Working With Twig Templates](https://www.drupal.  org/docs/develop/theming-drupal/twig-in-drupal/working-with-twig-templates)  
 


### PR DESCRIPTION
Since question 8 explicitly mentions custom theme, proposed change adds `custom` to the theme path as parent to the custom theme's directory per the recommendation in Drupal.org documentation on theme structure. See: https://www.drupal.org/docs/develop/theming-drupal/drupal-theme-folder-structure#s-theme-structure